### PR TITLE
Waypoint planning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ cuRobo performs trajectory optimization across many seeds in parallel to find a 
 <img width="500" src="images/rrt_compare.gif">
 </p>
 
+### Planning through waypoints
+
+Use ``MotionGen.plan_waypoints`` with ``Waypoint`` objects to generate a
+trajectory passing through multiple poses.
+
+```python
+from curobo.wrap.reacher.types import Waypoint
+
+waypoints = [Waypoint(pose1), Waypoint(pose2)]
+result = motion_gen.plan_waypoints(start_state, waypoints)
+trajectory = result.get_interpolated_plan()
+```
+
+Each segment is available in ``result.waypoint_plans``.
+
 
 ## Citation
 

--- a/src/curobo/wrap/reacher/types.py
+++ b/src/curobo/wrap/reacher/types.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional, Tuple, Union
 
+import torch
+
 # CuRobo
 from curobo.rollout.rollout_base import Goal
 from curobo.types.base import TensorDeviceType
@@ -33,6 +35,14 @@ class ReacherSolveType(Enum):
     BATCH_GOALSET = 3
     BATCH_ENV = 4
     BATCH_ENV_GOALSET = 5
+
+
+@dataclass
+class Waypoint:
+    """Intermediate pose and optional velocity for waypoint planning."""
+
+    pose: Pose
+    velocity: Optional[torch.Tensor] = None
 
 
 @dataclass

--- a/tests/motion_gen_waypoints_test.py
+++ b/tests/motion_gen_waypoints_test.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from curobo.types.base import TensorDeviceType
+from curobo.types.math import Pose
+from curobo.types.robot import JointState
+from curobo.wrap.reacher.motion_gen import MotionGen, MotionGenConfig, MotionGenPlanConfig
+from curobo.wrap.reacher.types import Waypoint
+
+
+@pytest.fixture(scope="module")
+def motion_gen():
+    tensor_args = TensorDeviceType()
+    world_file = "collision_table.yml"
+    robot_file = "franka.yml"
+    motion_gen_config = MotionGenConfig.load_from_robot_config(
+        robot_file,
+        world_file,
+        tensor_args,
+        use_cuda_graph=False,
+    )
+    mg = MotionGen(motion_gen_config)
+    return mg
+
+
+def test_plan_waypoints(motion_gen):
+    retract_cfg = motion_gen.get_retract_config()
+    start_state = JointState.from_position(retract_cfg.view(1, -1))
+    kin_state = motion_gen.compute_kinematics(start_state)
+    pose1 = kin_state.ee_pose.clone()
+    pose1.position[0, 0] -= 0.1
+    pose2 = kin_state.ee_pose.clone()
+    pose2.position[0, 1] += 0.1
+    wps = [Waypoint(pose1), Waypoint(pose2)]
+
+    result = motion_gen.plan_waypoints(start_state, wps, MotionGenPlanConfig(max_attempts=1))
+    assert result.success.item()
+    assert len(result.waypoint_plans) == 2
+    for wp_plan, target in zip(result.waypoint_plans, wps):
+        kin = motion_gen.compute_kinematics(wp_plan[-1].unsqueeze(0))
+        assert torch.norm(kin.ee_pos_seq - target.pose.position) < 0.01


### PR DESCRIPTION
## Summary
- add a `Waypoint` dataclass for pose waypoints
- extend `MotionGenResult` with a `waypoint_plans` field
- add `MotionGen.plan_waypoints` for planning through multiple waypoints
- update pose sequence example to use the new API
- document waypoint planning in README
- create unit test for `plan_waypoints`

## Testing
- `python -m py_compile src/curobo/wrap/reacher/motion_gen.py`
- `python -m py_compile src/curobo/wrap/reacher/types.py`
- `python -m py_compile tests/motion_gen_waypoints_test.py`
- *(failed to run pytest: `pytest` not installed and network restricted)*